### PR TITLE
Blocks 2.x update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+version: 2.1
+
+# Common executor configuration
+executors:
+  clojure:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
+    working_directory: ~/repo
+
+
+# Job definitions
+jobs:
+  style:
+    executor: clojure
+    steps:
+      - checkout
+      - run:
+          name: Install cljstyle
+          environment:
+            CLJSTYLE_VERSION: 0.12.1
+          command: |
+            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
+            tar -xzf cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
+      - run:
+          name: Check source formatting
+          command: "./cljstyle check --report"
+
+  lint:
+    executor: clojure
+    steps:
+      - checkout
+      - run:
+          name: Install clj-kondo
+          environment:
+            CLJ_KONDO_VERSION: 2019.12.14
+          command: |
+            wget https://github.com/borkdude/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
+            unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
+      - run:
+          name: Lint source code
+          command: "./clj-kondo --lint src test"
+
+  test:
+    executor: clojure
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-test-{{ checksum "project.clj" }}
+            - v1-test-
+      - run: lein deps
+      - run: lein check
+      - run: lein test
+      - save_cache:
+          key: v1-test-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+
+  coverage:
+    executor: clojure
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-coverage-{{ checksum "project.clj" }}
+            - v1-coverage-
+            - v1-test-
+      - run:
+          name: Generate test coverage
+          command: lein coverage --codecov
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-coverage-{{ checksum "project.clj" }}
+      - store_artifacts:
+          path: target/coverage
+          destination: coverage
+      - run:
+          name: Publish Coverage
+          command: 'bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json'
+
+
+# Workflow definitions
+workflows:
+  version: 2
+  test:
+    jobs:
+      - style
+      - lint
+      - test
+      - coverage:
+          requires:
+            - test

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,11 @@
+{:linters
+ {:consistent-alias
+  {:level :warning
+   :aliases {clojure.java.io io
+             clojure.set set
+             clojure.string str
+             clojure.tools.logging log
+             com.stuartsierra.component component
+             manifold.deferred d
+             manifold.stream s
+             multiformats.hash multihash}}}}

--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,4 @@
+;; vim: filetype=clojure
+{:padding-lines 2
+ :max-consecutive-blank-lines 3
+ :file-ignore #{".git" "target"}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/target
+/classes
+/checkouts
+/.lein-*
+/.nrepl-port
+/.clj-kondo/.cache
+pom.xml
+pom.xml.asc
+*.jar
+*.class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+Change Log
+==========
+
+All notable changes to this project will be documented in this file, which
+follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+
+## [Unreleased]
+
+This is a major update which upgrades to the 2.x line of
+[mvxcvi/blocks](//github.com/greglook/blocks).
+
+
+## 0.0.3 - 2018-11-26
+
+Initial project release
+
+
+[Unreleased]: https://github.com/amperity/greenlight/compare/0.0.3...HEAD

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2017 Amperity, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+blocks-blob
+===========
+
+[![CircleCI](https://circleci.com/gh/amperity/blocks-blob.svg?style=svg)](https://circleci.com/gh/amperity/blocks-blob)
+
+This library implements a [content-addressable](https://en.wikipedia.org/wiki/Content-addressable_storage)
+[block store](https://github.com/greglook/blocks) backed by an Azure Blob container.
+
+
+## Installation
+
+Library releases are published on Clojars. To use the latest version with
+Leiningen, add the following dependency to your project definition:
+
+[![Clojars Project](http://clojars.org/amperity/blocks-blob/latest-version.svg)](http://clojars.org/amperity/blocks-blob)
+
+
+## License
+
+Licensed under the Apache License, Version 2.0. See the [LICENSE](LICENSE) file
+for rights and restrictions.

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -16,11 +16,12 @@
     java.net.URI))
 
 
-(defn store
+(defn new-store
   [path]
-  (let [container-uri (URI. (System/getenv "BLOCKS_BLOB_TEST_URI"))
-        shared-access-key (StorageCredentialsSharedAccessSignature. (System/getenv "BLOCKS_BLOB_TEST_SAS_TOKEN"))]
-    (->
-      (blob-block-store container-uri shared-access-key
-                        :root (or path "user"))
-      (component/start))))
+  (some->
+    (System/getenv "BLOCKS_BLOB_TEST_URI")
+    (block/->store)
+    (assoc :root (if (str/ends-with? path "/")
+                   path
+                   (str path "/")))
+    (component/start)))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -9,13 +9,11 @@
     [clojure.string :as str]
     [clojure.tools.namespace.repl :refer [refresh]]
     [com.stuartsierra.component :as component]
-    [multihash.core :as multihash]
-    [multihash.digest :as digest])
+    [multiformats.hash :as multihash])
   (:import
     (com.microsoft.azure.storage
       StorageCredentialsSharedAccessSignature)
-    (java.net
-      URI)))
+    java.net.URI))
 
 
 (defn store

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -18,10 +18,11 @@
       URI)))
 
 
-(defn store [path]
+(defn store
+  [path]
   (let [container-uri (URI. (System/getenv "BLOCKS_BLOB_TEST_URI"))
         shared-access-key (StorageCredentialsSharedAccessSignature. (System/getenv "BLOCKS_BLOB_TEST_SAS_TOKEN"))]
     (->
       (blob-block-store container-uri shared-access-key
-                       :root (or path "user"))
+                        :root (or path "user"))
       (component/start))))

--- a/project.clj
+++ b/project.clj
@@ -1,23 +1,22 @@
-(defproject amperity/blocks-blob "0.0.3"
+(defproject amperity/blocks-blob "0.1.0-SNAPSHOT"
   :description "Content-addressable Azure Blob block store."
   :url "https://github.com/amperity/blocks-blob"
   :license {:name "Apache License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :aliases
-  {"coverage" ["with-profile" "+coverage" "cloverage"
-               "--ns-exclude-regex" "blocks.store.tests"]}
+  {"coverage" ["with-profile" "+coverage" "cloverage"]}
 
   :deploy-branches ["master"]
   :pedantic? :abort
 
   :dependencies
-  [[org.clojure/clojure "1.8.0"]
-   [org.clojure/tools.logging "0.4.0"]
-   [com.microsoft.azure/azure-storage "7.0.0"]
-   [com.stuartsierra/component "0.3.2"]
-   [mvxcvi/blocks "1.0.0"]
-   [mvxcvi/multihash "2.0.2"]]
+  [[org.clojure/clojure "1.10.1"]
+   [org.clojure/tools.logging "1.0.0"]
+   [com.microsoft.azure/azure-storage "8.6.3"]
+   [com.stuartsierra/component "1.0.0"]
+   [mvxcvi/blocks "2.0.3"]
+   [mvxcvi/multiformats "0.2.1"]]
 
   :test-selectors
   {:default (complement :integration)
@@ -26,20 +25,18 @@
   :profiles
   {:dev
    {:dependencies
-    [[org.slf4j/slf4j-simple "1.7.21" :exclusions [org.slf4j/slf4j-api]]
-     [mvxcvi/test.carly "0.4.1"]]}
+    [[org.slf4j/slf4j-simple "1.7.30"]
+     [org.slf4j/slf4j-api "1.7.30"]
+     [mvxcvi/blocks-tests "2.0.3"]]}
 
    :repl
    {:source-paths ["dev"]
-    :dependencies [[org.clojure/tools.namespace "0.2.11"]]
+    :dependencies [[org.clojure/tools.namespace "1.0.0"]]
     :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
 
    :test
    {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
 
    :coverage
-   {:plugins [[lein-cloverage "1.0.10"]]
-    :dependencies [[commons-logging "1.2"]
-                   [riddley "0.1.14"]]
-    :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
-               "-Dorg.apache.commons.logging.simplelog.defaultlog=trace"]}})
+   {:plugins [[lein-cloverage "1.1.2"]]
+    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=trace"]}})

--- a/src/blocks/store/blob.clj
+++ b/src/blocks/store/blob.clj
@@ -67,7 +67,6 @@
   (read-all
     [this]
     (log/trace "Opening Azure blob" (.getName blob))
-    #_(.getBlockBlobReference container blob-name)
     (.openInputStream blob))
 
 

--- a/src/blocks/store/blob.clj
+++ b/src/blocks/store/blob.clj
@@ -15,22 +15,12 @@
       StorageCredentialsSharedAccessSignature
       StorageException)
     (com.microsoft.azure.storage.blob
-      BlobProperties
       CloudBlob
-      CloudBlobClient
       CloudBlobContainer
-      CloudBlockBlob
-      ListBlobItem
-      SharedAccessBlobHeaders
-      SharedAccessBlobPolicy)
-    (java.io
-      InputStream
-      OutputStream)
+      CloudBlockBlob)
     java.net.URI
     java.time.Instant
-    java.util.Date
-    (org.apache.commons.io.input
-      BoundedInputStream)))
+    java.util.Date))
 
 
 ;; ## Blob Functions

--- a/src/blocks/store/blob.clj
+++ b/src/blocks/store/blob.clj
@@ -7,7 +7,8 @@
     [clojure.string :as str]
     [clojure.tools.logging :as log]
     [com.stuartsierra.component :as component]
-    [multihash.core :as multihash])
+    [manifold.stream :as s]
+    [multiformats.hash :as multihash])
   (:import
     (com.microsoft.azure.storage
       StorageCredentials
@@ -19,13 +20,24 @@
       CloudBlobClient
       CloudBlobContainer
       CloudBlockBlob
+      ListBlobItem
       SharedAccessBlobHeaders
       SharedAccessBlobPolicy)
     (java.io
       InputStream
       OutputStream)
-    (java.net
-      URI)))
+    java.net.URI
+    java.time.Instant
+    (org.apache.commons.io.input
+      BoundedInputStream)))
+
+
+;; ## Blob Functions
+
+(defn- hex?
+  "True if the value is a valid hexadecimal string."
+  [x]
+  (and (string? x) (re-matches #"[0-9a-fA-F]+" x)))
 
 
 (defn- id->path
@@ -36,28 +48,96 @@
   (str root (multihash/hex id)))
 
 
-(defn blob->stats
+(defn- blob->stats
+  "Return the stats map (with metadata) for a blob."
   [^CloudBlob blob]
-  (let [^BlobProperties properties (.getProperties blob)
-        name (last (str/split (.getName blob) #"/"))]
-    {:id (multihash/decode name)
-     :size (.getLength properties)
-     :source (.getPrimaryUri (.getSnapshotQualifiedStorageUri blob))
-     :stored-at (.getLastModified properties)}))
+  (let [properties (.getProperties blob)
+        blob-name (last (str/split (.getName blob) #"/"))]
+    (when (hex? blob-name)
+      (with-meta
+        {:id (multihash/parse blob-name)
+         :size (.getLength properties)
+         :stored-at (.toInstant (.getLastModified properties))}
+        {::source (.getPrimaryUri (.getSnapshotQualifiedStorageUri blob))
+         ::name (.getName blob)}))))
 
 
-(defn file->block
-  [^CloudBlobContainer container root stats]
-  (let [id (:id stats)
-        path (id->path root id)]
-    (block/with-stats
-      (data/lazy-block
-        id (:size stats)
-        (fn file-reader
-          []
-          (-> (.getBlockBlobReference container path)
-              (.openInputStream))))
-      (dissoc stats :id :size))))
+
+;; ## Blob Content
+
+(deftype BlobReader
+  [^CloudBlockBlob blob]
+
+  data/ContentReader
+
+  (read-all
+    [this]
+    (log/trace "Opening Azure blob" (.getName blob))
+    #_(.getBlockBlobReference container blob-name)
+    (.openInputStream blob))
+
+
+  (read-range
+    [this start end]
+    (log/tracef "Opening Azure blob %s byte range %s - %s"
+                (.getName blob)
+                (or start "start")
+                (or end "end"))
+    (.openInputStream blob
+                      (long (or start 0))
+                      (and end (- end (or start 0)))
+                      nil nil nil)))
+
+
+(alter-meta! #'->BlobReader assoc :private true)
+
+
+(defn- blob->block
+  "Construct a new block from the given block blob reference."
+  [blob stats]
+  (let [stat-meta (meta stats)]
+    (with-meta
+      (data/create-block
+        (:id stats)
+        (:size stats)
+        (:stored-at stats)
+        (->BlobReader blob))
+      stat-meta)))
+
+
+;; ## Blob Functions
+
+(defn- run-blobs!
+  "Run the provided function over all blobs in the container matching the given
+  query. The loop will terminate if the function returns false or nil."
+  [^CloudBlobContainer container path query f]
+  (let [{:keys [after before]} query]
+    ;; OPTIMIZE: if after/before share a common prefix we can narrow the range here.
+    (loop [blobs (.iterator (.listBlobs container path true))
+           limit (:limit query)]
+      (when-let [blob (and (or (nil? limit) (pos? limit))
+                           (.hasNext blobs)
+                           (.next blobs))]
+        (if-let [stats (blob->stats blob)]
+          (cond
+            ;; Skip block which occurs before :after marker.
+            (and after (not (pos? (compare (multihash/hex (:id stats)) after))))
+            (recur blobs limit)
+
+            ;; Terminate when encountering blocks after :before marker.
+            (and before (not (neg? (compare (multihash/hex (:id stats)) before))))
+            nil
+
+            ;; Otherwise, call function.
+            (f blob)
+            (recur blobs (dec limit))
+
+            ;; Function returned false, halt iteration.
+            :else nil)
+          ;; Ignore non-block blob.
+          (recur blobs limit))))))
+
+
 
 ;; ## Block Store
 
@@ -72,7 +152,9 @@
   (start
     [this]
     (if-not container
-      (assoc this :container (CloudBlobContainer. container-uri credentials))
+      (do
+        (log/info "Connecting to Azure blob container" container-uri)
+        (assoc this :container (CloudBlobContainer. container-uri credentials)))
       this))
 
 
@@ -85,50 +167,81 @@
 
   store/BlockStore
 
-  (-stat
-    [this id]
-    (let [path (id->path root id)
-          ^CloudBlob blob (.getBlockBlobReference container path)]
-      (when (and blob (.exists blob))
-        (blob->stats blob))))
-
-
   (-list
     [this opts]
-    (->> (.listBlobs container root true) ; lazy, flat list of blobs
-         (map blob->stats)
-         (store/select-stats opts)))
+    (let [out (s/stream 1000)]
+      (store/future'
+        (try
+          (run-blobs!
+            container root opts
+            (fn stream-block
+              [blob]
+              (if-let [stats (and (instance? CloudBlockBlob blob)
+                                  (blob->stats blob))]
+                ;; Publish block to stream.
+                @(s/put! out (blob->block blob stats))
+                ;; Doesn't look like a block - ignore and continue.
+                true)))
+          (catch Exception ex
+            (log/error ex "Failure listing blob container")
+            (s/put! out ex))
+          (finally
+            (s/close! out))))
+      (s/source-only out)))
+
+
+  (-stat
+    [this id]
+    (store/future'
+      (let [path (id->path root id)
+            blob (.getBlockBlobReference container path)]
+        (when (and blob (.exists blob))
+          (blob->stats blob)))))
 
 
   (-get
     [this id]
-    (when-let [stats (.-stat this id)]
-      (file->block container root stats)))
+    (store/future'
+      (let [path (id->path root id)
+            blob (.getBlockBlobReference container path)]
+        (when-let [stats (and blob (.exists blob) (blob->stats blob))]
+          (blob->block blob stats)))))
 
 
   (-put!
     [this block]
-    (let [path (id->path root (:id block))
-          ^CloudBlob blob (.getBlockBlobReference container path)]
-      (when-not (.exists blob)
-        (with-open [output (.openOutputStream blob)
-                    content (block/open block)]
-          (io/copy content output)))
-      (.-get this (:id block))))
+    (store/future'
+      (let [path (id->path root (:id block))
+            blob (.getBlockBlobReference container path)]
+        (if (.exists blob)
+          ;; Read existing blob.
+          (let [stats (blob->stats blob)]
+            (blob->block blob stats))
+          ;; Write blob.
+          (do
+            (with-open [output (.openOutputStream blob)
+                        content (data/content-stream block nil nil)]
+              (io/copy content output))
+            (let [blob (.getBlockBlobReference container path)
+                  stats (blob->stats blob)]
+              (blob->block blob stats)))))))
 
 
   (-delete!
     [this id]
-    (try
-      (let [path (id->path root id)
-            ^CloudBlob blob (.getBlockBlobReference container path)]
-        (log/debugf "Deleting file %s" (.getPrimaryUri (.getSnapshotQualifiedStorageUri blob)))
-        (.delete blob)
-        true)
-      (catch StorageException se
-        (when (not= 404 (.getHttpStatusCode se))
-          (throw se))
-        false))))
+    (store/future'
+      (try
+        (let [path (id->path root id)
+              blob (.getBlockBlobReference container path)]
+          (log/debugf "Deleting file %s" (.getPrimaryUri (.getSnapshotQualifiedStorageUri blob)))
+          (.delete blob)
+          true)
+        (catch StorageException se
+          (when (not= 404 (.getHttpStatusCode se))
+            (throw se))
+          false)))))
+
+
 
 ;; ## Store Construction
 
@@ -150,7 +263,7 @@
 
 
 (defn blob-block-store
-  [container-uri ^StorageCredentials credentials & {:as opts}]
+  [container-uri credentials & {:as opts}]
   (map->BlobBlockStore
     (assoc opts
            :credentials credentials

--- a/test/blocks/store/blob_test.clj
+++ b/test/blocks/store/blob_test.clj
@@ -17,6 +17,7 @@
 (def blob-uri (System/getenv "BLOCKS_BLOB_TEST_URI"))
 (def blob-sas-token (System/getenv "BLOCKS_BLOB_TEST_SAS_TOKEN"))
 
+
 (deftest ^:integration check-blob-store
   (if-let [test-store-uri blob-uri]
     (let [credentials (StorageCredentialsSharedAccessSignature. blob-sas-token)

--- a/test/blocks/store/blob_test.clj
+++ b/test/blocks/store/blob_test.clj
@@ -1,11 +1,9 @@
 (ns blocks.store.blob-test
   (:require
-    [blocks.core :as block]
     [blocks.store.blob :as blob :refer [blob-block-store]]
     [blocks.store.tests :as tests]
     [clojure.test :refer [deftest]]
-    [com.stuartsierra.component :as component]
-    [multiformats.hash :as multihash])
+    [com.stuartsierra.component :as component])
   (:import
     (com.microsoft.azure.storage
       StorageCredentialsSharedAccessSignature)

--- a/test/blocks/store/blob_test.clj
+++ b/test/blocks/store/blob_test.clj
@@ -3,32 +3,32 @@
     [blocks.core :as block]
     [blocks.store.blob :as blob :refer [blob-block-store]]
     [blocks.store.tests :as tests]
-    [clojure.test :refer :all]
-    [multihash.core :as multihash])
+    [clojure.test :refer [deftest]]
+    [com.stuartsierra.component :as component]
+    [multiformats.hash :as multihash])
   (:import
     (com.microsoft.azure.storage
       StorageCredentialsSharedAccessSignature)
-    (java.net
-      URI)))
+    java.net.URI))
 
 
 ;; ## Integration Tests
 
 (def blob-uri (System/getenv "BLOCKS_BLOB_TEST_URI"))
-(def blob-sas-token (System/getenv "BLOCKS_BLOB_TEST_SAS_TOKEN"))
 
 
 (deftest ^:integration check-blob-store
-  (if-let [test-store-uri blob-uri]
-    (let [credentials (StorageCredentialsSharedAccessSignature. blob-sas-token)
-          root-path (str "testing/blocks/test-" (rand-int 1000))
+  (if-let [uri (some-> blob-uri URI.)]
+    (let [credentials (StorageCredentialsSharedAccessSignature. (.getRawQuery uri))
+          root-path (str (.getPath uri) "testing/blocks/test-" (rand-int 1000))
           counter (atom 0)]
-      ; NOTE: can run concurrent tests by making this `check-store*` instead.
+      ;; NOTE: can run concurrent tests by making this `check-store*` instead.
       (tests/check-store
         (fn [& _]
-          (let [path (format "%s/%08d" root-path (swap! counter inc))
-                store (blob-block-store (URI. test-store-uri)
-                                        credentials
-                                        :root path)]
-            store))))
+          (let [path (format "%s/%08d" root-path (swap! counter inc))]
+            (component/start
+              (blob-block-store
+                (URI. "https" (.getHost uri) path nil)
+                credentials
+                :root path))))))
     (println "No BLOCKS_BLOB_TEST_URI in environment, skipping integration test!")))

--- a/test/blocks/store/blob_test.clj
+++ b/test/blocks/store/blob_test.clj
@@ -19,16 +19,16 @@
 
 (deftest ^:integration check-blob-store
   (if-let [uri (some-> blob-uri URI.)]
-    (let [credentials (StorageCredentialsSharedAccessSignature. (.getRawQuery uri))
-          root-path (str (.getPath uri) "testing/blocks/test-" (rand-int 1000))
+    (let [storage-uri (URI. "https" (.getHost uri) (.getPath uri) nil)
+          credentials (StorageCredentialsSharedAccessSignature. (.getRawQuery uri))
+          base-path (str "greg/blocks/test-" (rand-int 1000))
           counter (atom 0)]
       ;; NOTE: can run concurrent tests by making this `check-store*` instead.
       (tests/check-store
         (fn [& _]
-          (let [path (format "%s/%08d" root-path (swap! counter inc))]
+          (let [path (format "%s/%08d/" base-path (swap! counter inc))]
             (component/start
               (blob-block-store
-                (URI. "https" (.getHost uri) path nil)
-                credentials
+                storage-uri credentials
                 :root path))))))
     (println "No BLOCKS_BLOB_TEST_URI in environment, skipping integration test!")))


### PR DESCRIPTION
## Description

This updates the Azure Blob block store to be compatible with the (not really) new [2.X major version](https://github.com/greglook/blocks/blob/master/CHANGELOG.md#200---2019-03-05) of [mvxcvi/blocks](//github.com/greglook/blocks). This is rewritten along the lines of `blocks-s3` with a relatively simple future-wrapping upgrade to asynchrony.

Fixes #1.

## Testing

I ran the generative integration tests with some test credentials:

```
% lein test :integration

lein test blocks.store.blob-test
....................................................................................................

Generative tests passed after 100 trials with seed 1586709660153

Ran 101 tests containing 4540 assertions.
0 failures, 0 errors.
 Elapsed: 5:51.55 User: 37.64s Kernel: 2.957
```